### PR TITLE
fix+feat: unbound variable修正とログファイル出力対応 (v1.13.0)

### DIFF
--- a/generate-sso-profiles.sh
+++ b/generate-sso-profiles.sh
@@ -289,16 +289,16 @@ generate_profiles_for_accounts() {
                         profile_name=$(generate_profile_name "$prefix" "$account_name" "$account_id" "$role_name" "$normalization_type")
 
                         create_profile_config "$config_file" "$profile_name" "$account_id" "$role_name" "$region"
-                        log_success "プロファイル作成: $profile_name"
+                        log_to_file "✅ プロファイル作成: $profile_name"
                         role_count=$((role_count + 1))
                         total_profiles=$((total_profiles + 1))
                     fi
                 done < "$temp_roles_file"
 
                 rm -f "$temp_roles_file"
-                log_debug "アカウント $account_name: $role_count 個のプロファイルを処理"
+                log_to_file "アカウント $account_name: $role_count 個のプロファイルを処理"
             else
-                log_debug "アカウント $account_name のロール取得に失敗しました"
+                log_to_file "⚠️ アカウント $account_name のロール取得に失敗しました"
             fi
 
             count=$((count + 1))
@@ -403,6 +403,11 @@ main() {
 
     # AWS_PROFILE環境変数のチェック
     check_and_handle_aws_profile
+
+    # ログファイルの初期化
+    LOG_FILE="${HOME}/.aws/sso-profile-generator-$(date +%Y%m%d_%H%M%S).log"
+    echo "# AWS SSO Profile Generator Log - $(get_current_datetime)" > "$LOG_FILE"
+    log_info "ログファイル: $LOG_FILE"
 
     # 設定ファイルの取得
     local config_file
@@ -528,6 +533,7 @@ main() {
         echo
         log_success "プロファイル自動生成が完了しました！"
         log_info "生成されたプロファイルを確認するには: aws configure list-profiles"
+        log_info "詳細ログ: $LOG_FILE"
     else
         read -r -p "この設定でプロファイルを生成しますか？ (y/n): " confirm
         if [[ "$confirm" =~ ^[Yy]$ ]]; then
@@ -535,6 +541,7 @@ main() {
             echo
             log_success "プロファイル自動生成が完了しました！"
             log_info "生成されたプロファイルを確認するには: aws configure list-profiles"
+            log_info "詳細ログ: $LOG_FILE"
         else
             log_info "プロファイル生成をキャンセルしました"
         fi

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -44,6 +44,16 @@ log_debug() {
     fi
 }
 
+# ログファイル出力（カラーコードなし）
+LOG_FILE=""
+
+log_to_file() {
+    local message="$1"
+    if [ -n "${LOG_FILE:-}" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] $message" >> "$LOG_FILE"
+    fi
+}
+
 # 設定ファイルのパスを取得
 get_config_file() {
     if [ -n "$AWS_CONFIG_FILE" ]; then
@@ -546,38 +556,38 @@ get_access_token() {
     # SSO キャッシュディレクトリの存在確認
     if [ ! -d "$sso_cache_dir" ]; then
         log_error "SSO キャッシュディレクトリが見つかりません: $sso_cache_dir"
-        show_sso_login_command "$session_name"
+        show_sso_login_command "$SSO_SESSION_NAME"
         return 1
     fi
-    
+
     # SSO Start URLを含むJSONファイルを検索
     local cache_files
     cache_files=$(grep -l -r "$sso_start_url" "$sso_cache_dir" 2>/dev/null || true)
-    
+
     if [ -z "$cache_files" ]; then
         log_error "SSO セッションキャッシュが見つかりません"
-        show_sso_login_command "$session_name"
+        show_sso_login_command "$SSO_SESSION_NAME"
         return 1
     fi
-    
+
     # 複数ファイルがある場合は最新のファイルを取得
     local latest_file
     latest_file=$(echo "$cache_files" | xargs ls -t | head -n1)
-    
+
     log_info "SSO キャッシュファイル: $(basename "$latest_file")"
-    
+
     # jqでaccessTokenを取得
     if ! command -v jq &> /dev/null; then
         log_error "jq コマンドが見つかりません。jqをインストールしてください"
         return 1
     fi
-    
+
     local access_token
     access_token=$(jq -r '.accessToken // empty' "$latest_file" 2>/dev/null)
-    
+
     if [ -z "$access_token" ]; then
         log_error "アクセストークンが見つかりません"
-        show_sso_login_command "$session_name"
+        show_sso_login_command "$SSO_SESSION_NAME"
         return 1
     fi
     
@@ -617,7 +627,7 @@ get_access_token() {
         if [ "$expires_timestamp" -le "$current_timestamp" ]; then
             echo "  有効期限: $local_expires"
             log_error "SSO セッションが期限切れです"
-            show_sso_login_command "$session_name"
+            show_sso_login_command "$SSO_SESSION_NAME"
             return 1
         else
             log_success "有効なアクセストークンを取得しました"
@@ -626,7 +636,7 @@ get_access_token() {
     else
         log_success "有効なアクセストークンを取得しました（有効期限情報なし）"
     fi
-    
+
     export ACCESS_TOKEN="$access_token"
     return 0
 }


### PR DESCRIPTION
## Summary

- **fix**: `get_access_token` 内で `$session_name`（未定義変数）を参照していたバグを修正
  - `set -u` により SSO セッション期限切れ時に `unbound variable` エラーで異常終了していた
  - 正しくは `get_sso_config` がエクスポートする `$SSO_SESSION_NAME` を使用
- **feat**: プロファイル作成ログをファイル出力に切り替え、ターミナル表示を簡潔化
  - 182アカウント×3ロール≈546行の出力をプログレスバーのみに削減
  - 詳細ログは `~/.aws/sso-profile-generator-YYYYMMDD_HHmmss.log` に記録
  - 完了時にログファイルパスを表示

## Test plan

- [ ] `./generate-sso-profiles.sh --force` でプログレスバーのみ表示されることを確認
- [ ] `~/.aws/sso-profile-generator-*.log` に各プロファイル作成ログが記録されることを確認
- [ ] SSOセッション期限切れ時に正しいログインコマンド (`aws sso login --sso-session <name>`) が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)