### PR TITLE
chore: module path を aws-sso-profiles に統一 (リポジトリ名との乖離解消)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,7 +45,7 @@ homebrew_casks:
     commit_author:
       name: goreleaser-bot
       email: goreleaser-bot@users.noreply.github.com
-    homepage: "https://github.com/hacker65536/aws-sso-profile-generator"
+    homepage: "https://github.com/hacker65536/aws-sso-profiles"
     description: "Desired-state generator for AWS SSO profiles"
     skip_upload: auto
     # The binary is not signed/notarized; strip the quarantine bit on macOS so

--- a/cmd/aws-sso-profiles/main.go
+++ b/cmd/aws-sso-profiles/main.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/app"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/awsconfig"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/config"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/plan"
+	"github.com/hacker65536/aws-sso-profiles/internal/app"
+	"github.com/hacker65536/aws-sso-profiles/internal/awsconfig"
+	"github.com/hacker65536/aws-sso-profiles/internal/config"
+	"github.com/hacker65536/aws-sso-profiles/internal/plan"
 )
 
 // version, commit and date are overridden at build time via

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hacker65536/aws-sso-profile-generator
+module github.com/hacker65536/aws-sso-profiles
 
 go 1.26.5
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -14,13 +14,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/awsconfig"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/config"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/diskcache"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/plan"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/render"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/ssoapi"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/ssotoken"
+	"github.com/hacker65536/aws-sso-profiles/internal/awsconfig"
+	"github.com/hacker65536/aws-sso-profiles/internal/config"
+	"github.com/hacker65536/aws-sso-profiles/internal/diskcache"
+	"github.com/hacker65536/aws-sso-profiles/internal/plan"
+	"github.com/hacker65536/aws-sso-profiles/internal/render"
+	"github.com/hacker65536/aws-sso-profiles/internal/ssoapi"
+	"github.com/hacker65536/aws-sso-profiles/internal/ssotoken"
 )
 
 // DefaultConfigPath is used when --config is not given.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,10 +12,10 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"sigs.k8s.io/yaml"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/awsconfig"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/naming"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/plan"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/selector"
+	"github.com/hacker65536/aws-sso-profiles/internal/awsconfig"
+	"github.com/hacker65536/aws-sso-profiles/internal/naming"
+	"github.com/hacker65536/aws-sso-profiles/internal/plan"
+	"github.com/hacker65536/aws-sso-profiles/internal/selector"
 )
 
 //go:embed schema.json

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/awsconfig"
+	"github.com/hacker65536/aws-sso-profiles/internal/awsconfig"
 )
 
 const good = `

--- a/internal/config/schema.json
+++ b/internal/config/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/hacker65536/aws-sso-profile-generator/schema.json",
+  "$id": "https://github.com/hacker65536/aws-sso-profiles/schema.json",
   "title": "aws-sso-profiles config",
   "type": "object",
   "additionalProperties": false,

--- a/internal/diskcache/diskcache.go
+++ b/internal/diskcache/diskcache.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/ssoapi"
+	"github.com/hacker65536/aws-sso-profiles/internal/ssoapi"
 )
 
 // Cache is a directory-backed inventory cache.

--- a/internal/diskcache/diskcache_test.go
+++ b/internal/diskcache/diskcache_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/ssoapi"
+	"github.com/hacker65536/aws-sso-profiles/internal/ssoapi"
 )
 
 func sampleInv() []ssoapi.AccountRoles {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/awsconfig"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/naming"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/selector"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/ssoapi"
+	"github.com/hacker65536/aws-sso-profiles/internal/awsconfig"
+	"github.com/hacker65536/aws-sso-profiles/internal/naming"
+	"github.com/hacker65536/aws-sso-profiles/internal/selector"
+	"github.com/hacker65536/aws-sso-profiles/internal/ssoapi"
 )
 
 // IdentityKeys are tool-owned and must never appear in user settings.

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/awsconfig"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/naming"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/selector"
-	"github.com/hacker65536/aws-sso-profile-generator/internal/ssoapi"
+	"github.com/hacker65536/aws-sso-profiles/internal/awsconfig"
+	"github.com/hacker65536/aws-sso-profiles/internal/naming"
+	"github.com/hacker65536/aws-sso-profiles/internal/selector"
+	"github.com/hacker65536/aws-sso-profiles/internal/ssoapi"
 )
 
 func params() Params {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/plan"
+	"github.com/hacker65536/aws-sso-profiles/internal/plan"
 )
 
 // Provenance is the audit metadata stamped into the managed block's first line.

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/hacker65536/aws-sso-profile-generator/internal/plan"
+	"github.com/hacker65536/aws-sso-profiles/internal/plan"
 )
 
 var update = flag.Bool("update", false, "update golden files")


### PR DESCRIPTION
## 目的

リポジトリ名 `aws-sso-profile-generator` とコマンド/バイナリ名 `aws-sso-profiles` の乖離を、公開名であるコマンド側に寄せて解消する。`generator` は Bash 時代 (`generate-sso-profiles.sh`) の名残で、リポジトリ名は README 本文には一度も登場せず、実質 module path・import・URL にしか出ていなかった。

## 変更

module path `github.com/hacker65536/aws-sso-profile-generator` → `.../aws-sso-profiles` を一括置換 (13 ファイル):

- `go.mod` の module 宣言
- Go の import 文 (cmd + internal/*)
- `.goreleaser.yaml` の homepage URL
- `internal/config/schema.json` の `$id` URL

## 不変 (既存ユーザーへの影響なし)

- バイナリ / コマンド名 `aws-sso-profiles`
- config ファイル名 `.aws-sso-profiles.yaml`
- goreleaser project_name / cask name
- 永続マーカー `AWS_SSO_CONFIG_GENERATOR` (後方互換のため据え置き)

## 検証

- `go build ./...` / `go vet ./...` OK
- `go test ./...` 全パッケージ green
- `make build` → `aws-sso-profiles version` 従来どおり出力
- 旧文字列 grep 0 件

## 別途必要な手動ステップ

1. GitHub でリポジトリを rename: `aws-sso-profile-generator` → `aws-sso-profiles` (旧 URL は自動リダイレクト)
2. ローカル remote 更新: `git remote set-url origin https://github.com/hacker65536/aws-sso-profiles.git`

🤖 Generated with [Claude Code](https://claude.com/claude-code)