### PR TITLE
feat: AWS_SSO_PROFILES_CONFIG で config パスを指定可能に

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ aws-sso-profiles apply         # 冪等。管理ブロックのみ書換
 
 共通フラグ: `-c/--config`（既定 `./.aws-sso-profiles.yaml`）、`-o/--output human|json`、`-p/--parallel N`（既定 8, adaptive retry 併用）、`--login`（失効時に `aws sso login` を代行）、`--cache`（opt-in ディスクキャッシュ）、`--refresh-cache`。
 
+config パスは **`-c/--config` 明示指定 > 環境変数 `AWS_SSO_PROFILES_CONFIG` > 既定 `./.aws-sso-profiles.yaml`** の順で解決されます。別名 config を常用するなら `export AWS_SSO_PROFILES_CONFIG=~/.aws-sso-poc-profiles.yaml` としておけば `-c` を毎回付けずに済みます（`~` は展開されます）。
+
 ## config スキーマ（`.aws-sso-profiles.yaml`）
 
 ```yaml

--- a/cmd/aws-sso-profiles/main.go
+++ b/cmd/aws-sso-profiles/main.go
@@ -51,7 +51,7 @@ func rootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: false,
 	}
-	root.PersistentFlags().StringP("config", "c", app.DefaultConfigPath, "path to .aws-sso-profiles.yaml")
+	root.PersistentFlags().StringP("config", "c", app.DefaultConfigPath, "path to .aws-sso-profiles.yaml (env: AWS_SSO_PROFILES_CONFIG)")
 	root.PersistentFlags().StringP("output", "o", "human", "output format: human|json")
 	root.AddCommand(initCmd(), listCmd(), planCmd(), applyCmd(), validateCmd(), schemaCmd(), cleanupCmd(), checkCmd(), versionCmd())
 	return root
@@ -60,8 +60,21 @@ func rootCmd() *cobra.Command {
 // ---- helpers ----
 
 func loadApp(cmd *cobra.Command) (*app.App, error) {
-	cfgPath, _ := cmd.Flags().GetString("config")
-	return app.Load(cfgPath, version)
+	return app.Load(configPath(cmd), version)
+}
+
+// configPath resolves the config file path with precedence:
+// explicit --config > $AWS_SSO_PROFILES_CONFIG > flag default.
+func configPath(cmd *cobra.Command) string {
+	if cmd.Flags().Changed("config") {
+		v, _ := cmd.Flags().GetString("config")
+		return v
+	}
+	if env := os.Getenv(app.ConfigPathEnv); env != "" {
+		return env
+	}
+	v, _ := cmd.Flags().GetString("config")
+	return v
 }
 
 func invOptions(cmd *cobra.Command) app.InvOptions {
@@ -88,7 +101,7 @@ func initCmd() *cobra.Command {
 		Use:   "init",
 		Short: "Interactively create .aws-sso-profiles.yaml and the [sso-session] block",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cfgPath, _ := cmd.Flags().GetString("config")
+			cfgPath := configPath(cmd)
 			// Guard: never clobber an existing config without --force.
 			if !force {
 				if _, err := os.Stat(cfgPath); err == nil {

--- a/cmd/aws-sso-profiles/testdata/script/env_config.txtar
+++ b/cmd/aws-sso-profiles/testdata/script/env_config.txtar
@@ -1,0 +1,35 @@
+# AWS_SSO_PROFILES_CONFIG resolves the config path when -c is absent,
+# -c overrides it, and ~ is expanded. Precedence: -c > env > default.
+env AWS_CONFIG_FILE=$WORK/aws_config
+
+# env points at a valid config, no -c -> that config is read and validates OK
+env AWS_SSO_PROFILES_CONFIG=$WORK/env.yaml
+exec aws-sso-profiles validate
+stdout 'OK: config valid'
+
+# no env, no -c -> falls back to the default file name in the error
+env AWS_SSO_PROFILES_CONFIG=
+! exec aws-sso-profiles validate
+stderr 'read config .aws-sso-profiles.yaml'
+
+# env pointing at a missing file -> error names THAT path (proves env is honored)
+env AWS_SSO_PROFILES_CONFIG=$WORK/missing.yaml
+! exec aws-sso-profiles validate
+stderr 'read config .*missing.yaml'
+
+# explicit -c wins over env (env still points at the missing file)
+exec aws-sso-profiles validate -c env.yaml
+stdout 'OK: config valid'
+
+-- env.yaml --
+sso:
+  session: main
+defaults:
+  prefix: awssso
+  template: "{prefix}-{account_id}-{role}"
+
+-- aws_config --
+[sso-session main]
+sso_start_url = https://x/start
+sso_region = us-east-1
+sso_registration_scopes = sso:account:access

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,9 @@ import (
 // DefaultConfigPath is used when --config is not given.
 const DefaultConfigPath = ".aws-sso-profiles.yaml"
 
+// ConfigPathEnv overrides the default config path when --config is not given.
+const ConfigPathEnv = "AWS_SSO_PROFILES_CONFIG"
+
 // FakeInventoryEnv, when set to a JSON file path, bypasses AWS entirely and
 // loads the inventory from disk. Used by the E2E tests to drive the real binary
 // deterministically without network or credentials.
@@ -49,6 +52,7 @@ func Load(configPath, version string) (*App, error) {
 	if configPath == "" {
 		configPath = DefaultConfigPath
 	}
+	configPath = expandHome(configPath) // ~ 展開（env/flag/デフォルトのどの経路でも効かせる）
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return nil, fmt.Errorf("read config %s: %w", configPath, err)


### PR DESCRIPTION
## 背景

`aws-sso-profiles check` を `-c` 無しで実行するとデフォルト `.aws-sso-profiles.yaml` が cwd に無く失敗する。別名 config (`~/.aws-sso-poc-profiles.yaml` 等) を常用するケースで毎回 `-c` を付けるのが煩雑だったため、環境変数でデフォルト参照先を切り替えられるようにする。

## 変更内容

環境変数 `AWS_SSO_PROFILES_CONFIG` で config パスを指定可能にした。

**優先順位**: `-c/--config` 明示指定 > `AWS_SSO_PROFILES_CONFIG` > 既定 `.aws-sso-profiles.yaml`

- `internal/app/app.go`: 定数 `ConfigPathEnv` を追加。`Load` で `expandHome` を通し `~/...` を展開。
- `cmd/aws-sso-profiles/main.go`: 優先順位を解決する `configPath(cmd)` ヘルパーを新設 (`cmd.Flags().Changed("config")` で明示指定を判別)。`loadApp` (`check` 含む全サブコマンド共通) と `initCmd` で使用。フラグ help に env 名を追記。
- `README.md`: 解決順とユースケース例を追記。
- `testdata/script/env_config.txtar`: env 解決・`-c` 優先・env 未設定フォールバックの 3 分岐を検証する testscript を追加。

## 使い方

\`\`\`sh
export AWS_SSO_PROFILES_CONFIG=~/.aws-sso-poc-profiles.yaml
aws-sso-profiles check   # -c 無しで poc config が読まれる
\`\`\`

## 検証

- \`go build\` / \`go vet\` / \`go test ./...\` すべて green (新規 `env_config.txtar` 含む)。
- 実ケース: \`AWS_SSO_PROFILES_CONFIG=~/.aws-sso-poc-profiles.yaml aws-sso-profiles validate\` → \`OK: config valid\` (~ 展開込みで解決)。env 未設定時は従来どおり既定ファイル名でエラー。

🤖 Generated with [Claude Code](https://claude.com/claude-code)