### PR TITLE
feat: セキュリティ・ハードニング (INI インジェクション耐性・権限締結・cache 既定パス)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Go module dependencies (AWS SDK, cobra, jsonschema, ...).
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      aws-sdk:
+        patterns:
+          - "github.com/aws/*"
+
+  # GitHub Actions used by the CI / release workflows (pinned by SHA).
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ commit-message*.txt
 # 認証トークンの平文ファイル (誤コミット防止)
 token
 *.token
+
+# AWS config のバックアップ (AWS_CONFIG_FILE を repo 内に向けた場合の誤コミット防止)
+config.backup.*
+*.backup.20*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately via
+[GitHub Security Advisories](https://github.com/hacker65536/aws-sso-profiles/security/advisories/new)
+rather than opening a public issue. We aim to acknowledge reports within a few
+business days.
+
+When reporting, please include:
+
+- the version (`aws-sso-profiles version`) and OS,
+- a description of the impact, and
+- reproduction steps or a proof of concept if available.
+
+## Scope and threat model
+
+`aws-sso-profiles` is a local, single-user CLI. It:
+
+- reads `~/.aws/config` and the SSO bearer token that `aws sso login` cached
+  under `~/.aws/sso/cache` (**read-only**; it never writes or logs the token),
+- calls only the read-only AWS SSO Portal operations `ListAccounts` and
+  `ListAccountRoles`,
+- writes generated profiles into a marker-delimited *managed block* of
+  `~/.aws/config` (atomic write, timestamped backup + rotation), and
+- optionally shells out to `aws sso login` (argv form — no shell interpolation).
+
+Because it edits a credentials-adjacent file, the primary hardening goal is that
+**no data flowing in from the SSO API or the policy YAML can inject arbitrary
+content into `~/.aws/config`** (e.g. a `credential_process` line). Identity
+fields (account id, role name) and the rendered profile name are validated
+against strict character sets before rendering, and user-supplied settings
+keys/values are rejected if they contain newlines or square brackets.
+
+Out of scope: multi-user/path-traversal boundaries (all file paths are the
+invoking user's own), and the security of the AWS SDK / credential minting,
+which is delegated to the official `aws` CLI and AWS SDK for Go.
+
+## Supported versions
+
+Only the latest released version is supported. Please upgrade before reporting.

--- a/cmd/aws-sso-profiles/main.go
+++ b/cmd/aws-sso-profiles/main.go
@@ -138,7 +138,9 @@ func initCmd() *cobra.Command {
 				fmt.Fprintf(cmd.OutOrStdout(), "Wrote [sso-session %s] to %s\n", session, awsPath)
 			}
 
-			if err := os.WriteFile(cfgPath, []byte(initYAML(awsFile, session, startURL, region, prefix)), 0o644); err != nil {
+			// 0o600: the policy file records the SSO start URL, region and org
+			// prefix — not secrets, but org-identifying, so keep it owner-only.
+			if err := os.WriteFile(cfgPath, []byte(initYAML(awsFile, session, startURL, region, prefix)), 0o600); err != nil {
 				return err
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Wrote %s\n", cfgPath)

--- a/internal/awsconfig/awsconfig.go
+++ b/internal/awsconfig/awsconfig.go
@@ -349,6 +349,16 @@ func ManagedProfileNames(content string) map[string]bool {
 
 // ---- IO: backup + atomic write ----
 
+// ownerOnly strips group/other permission bits, keeping the file readable and
+// writable by its owner only (preserving the owner's existing rwx bits).
+func ownerOnly(mode os.FileMode) os.FileMode {
+	perm := mode.Perm() &^ os.FileMode(0o077)
+	if perm&0o600 == 0 {
+		perm |= 0o600 // guarantee the owner can still read/write it back
+	}
+	return mode&^os.FileMode(0o777) | perm
+}
+
 // Backup copies path to path.backup.<timestamp> and prunes to the newest keep.
 // If path does not exist, it is a no-op returning an empty backup path.
 func Backup(path string, keep int) (string, error) {
@@ -364,6 +374,7 @@ func Backup(path string, keep int) (string, error) {
 	if info != nil {
 		mode = info.Mode()
 	}
+	mode = ownerOnly(mode) // never let a backup be group/other-readable
 	bak := path + ".backup." + time.Now().Format("20060102_150405")
 	if err := os.WriteFile(bak, data, mode); err != nil {
 		return "", err
@@ -393,6 +404,10 @@ func WriteAtomic(path, content string) error {
 	if info, err := os.Stat(path); err == nil {
 		mode = info.Mode()
 	}
+	// Mode preservation must never *loosen*: an existing 0644 ~/.aws/config is
+	// tightened to owner-only here, since the managed block carries account/role
+	// identifiers that should not be group/other-readable.
+	mode = ownerOnly(mode)
 	tmp, err := os.CreateTemp(dir, ".aws-sso-profiles-*.tmp")
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,11 +131,22 @@ func (c *Config) semantic() error {
 	return nil
 }
 
-// checkSettings rejects tool-owned identity keys in a user settings map.
+// checkSettings rejects tool-owned identity keys in a user settings map, and
+// guards against INI injection: a key or value containing a newline or square
+// bracket could splice an extra stanza/line (e.g. `credential_process = ...`)
+// into ~/.aws/config when the block is rendered. The YAML is user-owned, but
+// this catches footguns in shared or machine-generated policy files.
 func checkSettings(where string, settings map[string]string) error {
-	for k := range settings {
+	const unsafe = "\n\r[]"
+	for k, v := range settings {
 		if plan.IdentityKeys[k] {
 			return fmt.Errorf("%s must not set the tool-owned key %q (identity keys are managed automatically)", where, k)
+		}
+		if strings.ContainsAny(k, unsafe) {
+			return fmt.Errorf("%s has a key containing a newline or square bracket (INI-injection guard): %q", where, k)
+		}
+		if strings.ContainsAny(v, unsafe) {
+			return fmt.Errorf("%s value for key %q contains a newline or square bracket (INI-injection guard)", where, k)
 		}
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -69,6 +69,15 @@ func TestSettingsRejectsIdentityKey(t *testing.T) {
 	}
 }
 
+func TestSettingsRejectsInjectionValue(t *testing.T) {
+	// A newline in a settings value would splice an extra line into the managed
+	// INI block; checkSettings must reject it (schema still sees a valid string).
+	_, err := Parse([]byte("defaults:\n  settings:\n    region: \"us-east-1\\ncredential_process = /bin/sh\"\n"))
+	if err == nil {
+		t.Error("expected INI-injection error for newline in settings value")
+	}
+}
+
 func TestSettingsRejectsNonStringValue(t *testing.T) {
 	// unquoted number must fail schema (values must be strings)
 	_, err := Parse([]byte("defaults:\n  settings:\n    duration_seconds: 3600\n"))

--- a/internal/diskcache/diskcache.go
+++ b/internal/diskcache/diskcache.go
@@ -25,12 +25,21 @@ type Cache struct {
 	TTL time.Duration
 }
 
-// New builds a Cache from CACHE_DIR (default ./.aws-sso-cache) and
-// CACHE_EXPIRY_HOURS (default 24).
+// New builds a Cache from CACHE_DIR and CACHE_EXPIRY_HOURS (default 24).
+//
+// When CACHE_DIR is unset the cache lives under the user cache directory
+// (~/.cache/aws-sso-profiles on Linux, ~/Library/Caches/... on macOS) rather
+// than a CWD-relative ./.aws-sso-cache. The snapshot contains real account IDs
+// and names, so anchoring it to a fixed per-user location avoids scattering
+// copies across working directories where they could be accidentally committed.
 func New() *Cache {
 	dir := os.Getenv("CACHE_DIR")
 	if dir == "" {
-		dir = ".aws-sso-cache"
+		if ucd, err := os.UserCacheDir(); err == nil {
+			dir = filepath.Join(ucd, "aws-sso-profiles")
+		} else {
+			dir = ".aws-sso-cache" // last-resort fallback if the user cache dir is undiscoverable
+		}
 	}
 	hours := 24.0
 	if v := os.Getenv("CACHE_EXPIRY_HOURS"); v != "" {
@@ -42,6 +51,8 @@ func New() *Cache {
 }
 
 func key(startURL string) string {
+	// md5 is used purely as a non-cryptographic cache-key digest (byte-for-byte
+	// parity with the original bash tool's key); it is not a security control.
 	sum := md5.Sum([]byte(startURL))
 	return hex.EncodeToString(sum[:])[:8]
 }
@@ -81,11 +92,23 @@ func (c *Cache) Save(startURL string, inv []ssoapi.AccountRoles) error {
 		return err
 	}
 	p := c.path(startURL)
-	tmp := p + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+	// Write via a randomized temp name (not a fixed p+".tmp") so a co-user in
+	// the cache dir cannot pre-create/symlink the temp path to redirect the
+	// write. os.CreateTemp makes the file 0600; the rename is atomic.
+	tmp, err := os.CreateTemp(c.Dir, "inventory-*.json.tmp")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, p)
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, p)
 }
 
 // Clear removes all cached inventory snapshots.

--- a/internal/diskcache/diskcache_test.go
+++ b/internal/diskcache/diskcache_test.go
@@ -66,6 +66,18 @@ func TestClear(t *testing.T) {
 	}
 }
 
+func TestNewDefaultDirUsesUserCache(t *testing.T) {
+	t.Setenv("CACHE_DIR", "") // force the default path
+	ucd, err := os.UserCacheDir()
+	if err != nil {
+		t.Skip("no user cache dir on this platform")
+	}
+	c := New()
+	if want := filepath.Join(ucd, "aws-sso-profiles"); c.Dir != want {
+		t.Errorf("default cache dir = %q, want %q", c.Dir, want)
+	}
+}
+
 func TestNewFromEnv(t *testing.T) {
 	t.Setenv("CACHE_DIR", "/tmp/asp-cache-test")
 	t.Setenv("CACHE_EXPIRY_HOURS", "1")

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -7,6 +7,7 @@ package plan
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -19,6 +20,44 @@ import (
 // IdentityKeys are tool-owned and must never appear in user settings.
 var IdentityKeys = map[string]bool{
 	"sso_session": true, "sso_account_id": true, "sso_role_name": true,
+}
+
+// Validation charsets for AWS-sourced identity fields and the rendered profile
+// name. These are a defense-in-depth guard: values flow verbatim from the SSO
+// Portal API into ~/.aws/config, so a compromised or spoofed endpoint returning
+// a role name (or an account name that survives normalization) containing a
+// newline or `]` could otherwise break out of the `[profile NAME]` header and
+// inject an arbitrary stanza (e.g. `credential_process = /bin/evil`) — arbitrary
+// code execution the next time that profile is used. We fail closed rather than
+// trust AWS's server-side input validation as our only line of defense.
+var (
+	// accountIDRe accepts digits only. AWS account IDs are canonically 12
+	// digits, but we intentionally do not pin the length: the point here is to
+	// forbid INI-structural characters (a digit string can never break INI),
+	// and short synthetic IDs are used by tests and the ASP_FAKE_INVENTORY hook.
+	accountIDRe = regexp.MustCompile(`^[0-9]+$`)
+	// roleNameRe mirrors the AWS permission-set / role name charset; it cannot
+	// contain a newline, `[`, or `]`.
+	roleNameRe = regexp.MustCompile(`^[A-Za-z0-9+=,.@_-]+$`)
+	// profileNameRe bounds the fully-rendered profile name (template output).
+	// It permits the characters the default template emits (`:` and `/` in
+	// addition to the role charset) while excluding newline and brackets.
+	profileNameRe = regexp.MustCompile(`^[A-Za-z0-9+=,.@:/_-]+$`)
+)
+
+// validateProfile rejects any identity value or rendered name that could break
+// out of the managed INI block. Called for every desired profile before render.
+func validateProfile(p Profile) error {
+	if !accountIDRe.MatchString(p.AccountID) {
+		return fmt.Errorf("account id %q is not all digits — refusing to write it into ~/.aws/config", p.AccountID)
+	}
+	if !roleNameRe.MatchString(p.RoleName) {
+		return fmt.Errorf("role name %q contains characters outside [A-Za-z0-9+=,.@_-] — refusing to write it into ~/.aws/config", p.RoleName)
+	}
+	if !profileNameRe.MatchString(p.Name) {
+		return fmt.Errorf("rendered profile name %q contains characters unsafe in an INI header; adjust defaults.template or defaults.prefix", p.Name)
+	}
+	return nil
 }
 
 // Params carries the config policy needed to build desired profiles.
@@ -63,6 +102,9 @@ func BuildDesired(inv []ssoapi.AccountRoles, p Params) ([]Profile, error) {
 			}
 			settings := mergeSettings(p.DefaultSettings, p.Overrides.Settings(ar.Account.Name, role))
 			prof := Profile{Name: name, SSOSession: p.SSOSession, AccountID: ar.Account.ID, RoleName: role, Settings: settings}
+			if err := validateProfile(prof); err != nil {
+				return nil, err
+			}
 			if prev, dup := seen[name]; dup {
 				collisions = append(collisions, fmt.Sprintf("%q (from %s:%s and %s:%s)",
 					name, prev.AccountID, prev.RoleName, prof.AccountID, prof.RoleName))

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -52,6 +52,25 @@ func TestBuildDesired(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredRejectsInjection(t *testing.T) {
+	cases := []struct {
+		name string
+		inv  []ssoapi.AccountRoles
+	}{
+		{"role newline", []ssoapi.AccountRoles{{Account: ssoapi.Account{ID: "1", Name: "acct"},
+			Roles: []string{"Admin\n[profile evil]\ncredential_process = /bin/sh"}}}},
+		{"role bracket", []ssoapi.AccountRoles{{Account: ssoapi.Account{ID: "1", Name: "acct"},
+			Roles: []string{"Ad]min"}}}},
+		{"account id non-digit", []ssoapi.AccountRoles{{Account: ssoapi.Account{ID: "12a", Name: "acct"},
+			Roles: []string{"Admin"}}}},
+	}
+	for _, tc := range cases {
+		if _, err := BuildDesired(tc.inv, params()); err == nil {
+			t.Errorf("%s: expected validation error, got none", tc.name)
+		}
+	}
+}
+
 func TestBuildDesiredCollision(t *testing.T) {
 	p := params()
 	p.Template = "{prefix}-{account_name}" // drops account_id + role → guaranteed collisions


### PR DESCRIPTION
## 背景

`~/.aws/config` は認証情報に隣接する高価値ファイル。実装レビューの結果、基本設計（shell injection なし・token read-only・atomic write + backup・marker スコープ splice）は堅牢だったが、**多層防御の穴**がいくつか見つかったため fail-closed のガードを追加する。機能変更ではなくガード追加が中心で、正常データは全て通過し後方互換。

## 変更点

### P1: INI インジェクション耐性（最重要） — `internal/plan/plan.go`
`role` / `account_id` は SSO API 由来のまま config に書かれるため、改行や `]` を含む値で `[profile evil]\ncredential_process = ...` を注入されると、そのプロファイル使用時にコード実行につながりうる。`BuildDesired` にプロファイル生成直後の `validateProfile` を追加:
- `account_id`: 数字のみ
- `role`: AWS 許容文字集合 `[A-Za-z0-9+=,.@_-]`
- 生成後の profile 名: 改行・角括弧を排除

> **Note**: 計画段階では account_id を `^\d{12}$` としていたが、**数字のみ**に変更。合成 ID (`"1"`,`"2"`) を使う既存テストと `ASP_FAKE_INVENTORY`（公開機能）を壊さず、注入は数字のみで完全に塞げるため。

### P2: settings 値の検証 — `internal/config/config.go`
`checkSettings` で key/value に改行・角括弧を含む場合を拒否（共有/生成 YAML の footgun 対策）。

### P3: cache 既定パス — `internal/diskcache/diskcache.go`
`CACHE_DIR` 未設定時の既定を CWD 相対 `.aws-sso-cache` → `os.UserCacheDir()/aws-sso-profiles`。実アカウント情報の散在・誤コミットを防止。`CACHE_DIR` 明示は従来通り尊重。

### P4: 堅牢性
- diskcache の temp 書込みを固定名 → `os.CreateTemp`（symlink/事前作成 race 対策）
- ⚠️ **挙動変更**: `awsconfig` の write/backup で group/other ビットを落とす `ownerOnly` を追加。既存 `0644` の `~/.aws/config` は `0600` に締結される。共有前提で `0644` を意図している運用があれば要確認。

### P5: 運用/サプライチェーン
- `init` の YAML を `0644` → `0600`、md5 の非暗号 intent をコメント明記
- `.gitignore` に config backup パターン追加、`SECURITY.md`・`.github/dependabot.yml` を新設

## テスト / 検証
- 各パッケージに注入を弾く負のテストを追加
- `go vet` / `go test -race ./...` 全通過
- 実バイナリでの end-to-end 確認:
  - 正常 apply 成功、`~/.aws/config` の mode が 644 → 600 に締結（backup も 600）
  - account_id `12a]` → 明確なエラーで書込み拒否 (exit 1)
  - `]` 入り role → 明確なエラーで拒否 (exit 1)
  - 改行入り role → selector が手前で除外（書き込まれない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)